### PR TITLE
Bump version: 2.0.0 → 2.0.1

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 2.0.0
+current_version = 2.0.1
 commit = True
 tag = False
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -10,7 +10,7 @@ project = 'ricco'
 copyright = '2024, wangyukang'
 author = 'wangyukang'
 
-release = '2.0.0'
+release = '2.0.1'
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
 

--- a/src/ricco/__init__.py
+++ b/src/ricco/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '2.0.0'
+__version__ = '2.0.1'
 
 from .base import ensure_list
 from .base import is_empty


### PR DESCRIPTION
## Summary by Sourcery

Bump project version to 2.0.1 across configuration and documentation.

Build:
- Update bumpversion configuration to set the current version to 2.0.1.

Documentation:
- Update Sphinx documentation configuration to reflect version 2.0.1.